### PR TITLE
specify scope for this repo; provide guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Tutorials for the Structural Simulation Toolkit (SST)
+
+scope for this repo: tutorials that are intended as self-paced walkthroughs
+
+Contributions to this repository should be submitted as pull requests.
+
+Documentation should be in Markdown format.
+
+Each tutorial is tied to a specific release of SST and may not be able to run with the current version of SST. 
+Contributions that update the compatablity of a tutorial with more recent versions of SST are welcome. 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Documentation should be in Markdown format.
 
 Each tutorial is tied to a specific release of SST and may not be able to run with the current version of SST. 
 Contributions that update the compatablity of a tutorial with more recent versions of SST are welcome. 
+
+After submitting a tutorial as a pull request, the owners of this repo review the submission and confirm
+- Documentation/information is correct with respect to the latest SST release
+- Code works with latest SST release
+- Tutorial is finished with no missing pieces. This does not mean the documentation needs to cover everything, just that there shouldn’t be incomplete sections, or references to code or documentation that doesn’t exist yet, etc. 


### PR DESCRIPTION
- included caveat about relation of tutorials to SST version
- specified that preferred format is Markdown